### PR TITLE
chore(husky): fix husky deprecation warnings

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -21,3 +21,59 @@ This document is a collaborative development journal maintained with AI assistan
   * Used `web_fetch` to get the `.gitignore` content from the official GitHub repository.
 * **Insights:**
   * Directly fetching files from reliable sources can be a more robust approach than relying on command-line tools that may not be installed or configured correctly.
+
+---
+
+**Date:** 2025-06-27
+**Author:** Gemini
+
+**Entry:**
+
+* **Feature:** Conventional Commits and Branching Strategy
+* **Progress:**
+  * Configured the project to use Conventional Commits with `commitizen` and `commitlint`.
+  * Added a `pre-commit` hook to lint markdown files.
+  * Added a `pre-push` hook to validate branch names.
+  * Created a `PULL_REQUEST_TEMPLATE.md`.
+* **Challenges:** None
+* **Solutions:** None
+* **Insights:** None
+
+---
+
+**Date:** 2025-06-27
+**Author:** Gemini
+
+**Entry:**
+
+* **Feature:** Branch Management Enhancements
+* **Progress:**
+  * Modified `pre-push` hook to prevent direct pushes to `main` branch.
+  * Added `.markdownlintignore` to exclude `node_modules` from linting.
+  * Updated `husky` hook scripts to remove deprecated lines.
+* **Challenges:**
+  * Initial `markdownlint` run linted `node_modules`.
+  * `husky` deprecation warnings.
+* **Solutions:**
+  * Added `.markdownlintignore`.
+  * Updated `husky` scripts.
+* **Insights:**
+  * It's important to configure linters to ignore irrelevant directories to avoid unnecessary warnings and improve performance.
+  * Keeping `husky` hooks up-to-date is crucial for maintaining a healthy development workflow.
+
+---
+
+**Date:** 2025-06-27
+**Author:** Gemini
+
+**Entry:**
+
+* **Feature:** Pull Request Template Fix
+* **Progress:**
+  * Modified `PULL_REQUEST_TEMPLATE.md` to use HTML checkboxes for better rendering in GitHub.
+* **Challenges:**
+  * Markdown checkboxes in PR template were not rendering correctly.
+* **Solutions:**
+  * Switched to HTML checkboxes in the template.
+* **Insights:**
+  * HTML elements can provide more consistent rendering in markdown across different platforms.


### PR DESCRIPTION
This pull request addresses the husky deprecation warnings by updating the hook scripts in , , and  to remove the deprecated boilerplate. This ensures the project's git hooks function correctly without warnings.\n\n## Checklist\n\n- <input type="checkbox" /> I have read the **CONTRIBUTING** document.\n- <input type="checkbox" /> I have updated the  file.\n- <input type="checkbox" /> I have added tests to cover my changes.\n- <input type="checkbox" /> All new and existing tests passed.\n- <input type="checkbox" /> I have updated the documentation.\n- <input type="checkbox" /> I have followed the code style of this project.\n- <input type="checkbox" /> I have performed a self-review of my own code.\n- <input type="checkbox" /> I have commented my code, particularly in hard-to-understand areas.\n- <input type="checkbox" /> I have made corresponding changes to the documentation.\n- <input type="checkbox" /> My changes generate no new warnings.\n- <input type="checkbox" /> I have added tests that prove my fix is effective or that my feature works.\n- <input type="checkbox" /> New and existing unit tests pass locally with my changes.\n- <input type="checkbox" /> Any dependent changes have been merged and published in downstream modules.