### PR TITLE
chore(lint): add lint:md script and fix husky deprecation

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no-install commitlint --edit "$1"

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -77,3 +77,17 @@ This document is a collaborative development journal maintained with AI assistan
   * Switched to HTML checkboxes in the template.
 * **Insights:**
   * HTML elements can provide more consistent rendering in markdown across different platforms.
+
+---
+
+**Date:** 2025-06-27
+**Author:** Gemini
+
+**Entry:**
+
+* **Chore:** Add lint:md script
+* **Progress:**
+  * Added `lint:md` script to `package.json` to run `markdownlint`.
+* **Challenges:** None
+* **Solutions:** None
+* **Insights:** None

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "lint:md": "markdownlint -f \"**/*.md\" --ignore \"node_modules/**\"",
     "prepare": "husky"
   },
   "keywords": [],


### PR DESCRIPTION
This pull request adds a  script to  for linting markdown files. It also addresses the persistent husky deprecation warnings by updating the hook scripts in , , and  to remove the deprecated boilerplate.\n\n## Checklist\n\n- <input type="checkbox" /> I have read the **CONTRIBUTING** document.\n- <input type="checkbox" /> I have updated the  file.\n- <input type="checkbox" /> I have added tests to cover my changes.\n- <input type="checkbox" /> All new and existing tests passed.\n- <input type="checkbox" /> I have updated the documentation.\n- <input type="checkbox" /> I have followed the code style of this project.\n- <input type="checkbox" /> I have performed a self-review of my own code.\n- <input type="checkbox" /> I have commented my code, particularly in hard-to-understand areas.\n- <input type="checkbox" /> I have made corresponding changes to the documentation.\n- <input type="checkbox" /> My changes generate no new warnings.\n- <input type="checkbox" /> I have added tests that prove my fix is effective or that my feature works.\n- <input type="checkbox" /> New and existing unit tests pass locally with my changes.\n- <input type="checkbox" /> Any dependent changes have been merged and published in downstream modules.